### PR TITLE
Update CircleCI Orb to Ensure Cache Key References Kotlin Gradle Scripts

### DIFF
--- a/src/commands/install_android_gradle_dependencies.yml
+++ b/src/commands/install_android_gradle_dependencies.yml
@@ -1,5 +1,5 @@
 description: >
-  Install your Android gradle packages with automated caching and best practices applied. Requires build.gradle file.
+  Install your Android gradle packages with automated caching and best practices applied. Requires build.gradle or build.gradle.kts file.
 parameters:
   app-dir:
     default: .
@@ -11,7 +11,7 @@ parameters:
     type: string
 steps:
   - restore_cache:
-      key: gradle-<<parameters.cache-version>>-{{ checksum  "<< parameters.app-dir >>/android/app/build.gradle" }}
+      key: gradle-<<parameters.cache-version>>-{{ checksum  "<< parameters.app-dir >>/android/app/build.gradle || << parameters.app-dir >>/android/app/build.gradle.kts" }}
   - run:
       name: Installing Android gradle packages
       command: gradle androidDependencies
@@ -20,4 +20,4 @@ steps:
       paths:
         - ~/.gradle/caches
         - ~/.gradle/wrapper
-      key: gradle-<<parameters.cache-version>>-{{ checksum  "<< parameters.app-dir >>/android/app/build.gradle" }}
+      key: gradle-<<parameters.cache-version>>-{{ checksum  "<< parameters.app-dir >>/android/app/build.gradle || << parameters.app-dir >>/android/app/build.gradle.kts" }}

--- a/src/commands/install_android_gradle_dependencies.yml
+++ b/src/commands/install_android_gradle_dependencies.yml
@@ -10,8 +10,16 @@ parameters:
     description: Change the default cache version if you need to clear the cache for any reason.
     type: string
 steps:
+  - run:
+      name: Calculate cache key
+      command: |
+        if [ -f "<< parameters.app-dir >>/android/app/build.gradle" ]; then
+          md5sum << parameters.app-dir >>/android/app/build.gradle > ~/gradle_cache_key
+        else
+          md5sum << parameters.app-dir >>/android/app/build.gradle.kts > ~/gradle_cache_key
+        fi
   - restore_cache:
-      key: gradle-<<parameters.cache-version>>-{{ checksum  "<< parameters.app-dir >>/android/app/build.gradle || << parameters.app-dir >>/android/app/build.gradle.kts" }}
+      key: gradle-<<parameters.cache-version>>-{{ checksum  "~/gradle_cache_key" }}
   - run:
       name: Installing Android gradle packages
       command: gradle androidDependencies
@@ -20,4 +28,4 @@ steps:
       paths:
         - ~/.gradle/caches
         - ~/.gradle/wrapper
-      key: gradle-<<parameters.cache-version>>-{{ checksum  "<< parameters.app-dir >>/android/app/build.gradle || << parameters.app-dir >>/android/app/build.gradle.kts" }}
+      key: gradle-<<parameters.cache-version>>-{{ checksum  "~/gradle_cache_key" }}


### PR DESCRIPTION
Since Flutter 3.27 now supports Kotlin scripts for Gradle, I have updated the CircleCI orb accordingly.